### PR TITLE
Fix hardcoded config parameters

### DIFF
--- a/src/Amqp/Silex/Provider/AmqpConnectionProvider.php
+++ b/src/Amqp/Silex/Provider/AmqpConnectionProvider.php
@@ -13,22 +13,33 @@ class AmqpConnectionProvider extends \Pimple
     {
         $provider = $this;
         foreach ($options as $key => $connection) {
-            $this['default'] = $this->share(function () use ($connection, $provider) {
-                return $provider->createConnection($connection['host'], $connection['port'], $connection['username'], $connection['password'], $connection['vhost']);
+            $this[$key] = $this->share(function () use ($connection, $provider) {
+                return $provider->createConnection(
+                    $connection['host'],
+                    $connection['port'],
+                    $connection['username'],
+                    $connection['password'],
+                    $connection['vhost']
+                );
             });
         }
     }
 
     /**
-     * @param  string          $host
-     * @param  integer         $port
-     * @param  string          $username
-     * @param  string          $password
-     * @param  string          $vhost
+     * @param  string $host
+     * @param  integer $port
+     * @param  string $username
+     * @param  string $password
+     * @param  string $vhost
      * @return \AMQPConnection
      */
-    public function createConnection($host = 'localhost', $port = 5672, $username = 'guest', $password = 'guest', $vhost = '/')
-    {
+    public function createConnection(
+        $host = 'localhost',
+        $port = 5672,
+        $username = 'guest',
+        $password = 'guest',
+        $vhost = '/'
+    ) {
         return new AMQPConnection($host, $port, $username, $password, $vhost);
     }
 }

--- a/src/Amqp/Silex/Provider/AmqpServiceProvider.php
+++ b/src/Amqp/Silex/Provider/AmqpServiceProvider.php
@@ -21,17 +21,25 @@ class AmqpServiceProvider implements ServiceProviderInterface
      */
     public function register(Application $app)
     {
-        $app[self::AMQP_CONNECTIONS] = array(
-            'default' => array(
-                'host' => 'localhost',
-                'port' => 5672,
-                'username' => 'guest',
-                'password' => 'guest',
-                'vhost' => '/'
-            )
-        );
+        if (empty($app[self::AMQP_CONNECTIONS])) {
+            $app[self::AMQP_CONNECTIONS] = array(
+                'default' => array(
+                    'host' => 'localhost',
+                    'port' => 5672,
+                    'username' => 'guest',
+                    'password' => 'guest',
+                    'vhost' => '/',
+                ),
+            );
+        }
 
-        $app[self::AMQP_FACTORY] = $app->protect(function ($host = 'localhost', $port = 5672, $username = 'guest', $password = 'guest', $vhost = '/') use ($app) {
+        $app[self::AMQP_FACTORY] = $app->protect(function (
+            $host = 'localhost',
+            $port = 5672,
+            $username = 'guest',
+            $password = 'guest',
+            $vhost = '/'
+        ) use ($app) {
             return $app[self::AMQP]->createConnection($host, $port, $username, $password, $vhost);
         });
 
@@ -48,5 +56,6 @@ class AmqpServiceProvider implements ServiceProviderInterface
      * a service must be requested).
      */
     public function boot(Application $app)
-    {}
+    {
+    }
 }


### PR DESCRIPTION
Your code rewrites incoming config parameters and doesn't allow to create multiple connection. So I offer this  little change. 
- Add `if` before reassigning `$app[self::AMQP_CONNECTIONS]` 
- Assign  `$this[$key]` instead of ` $this['default']` inside the `foreach`